### PR TITLE
Change from broken DOMDocument to using preg_replace instead

### DIFF
--- a/src/app/code/community/Leytech/CssJsVersion/Helper/Data.php
+++ b/src/app/code/community/Leytech/CssJsVersion/Helper/Data.php
@@ -47,46 +47,28 @@ class Leytech_CssJsVersion_Helper_Data extends Mage_Core_Helper_Abstract
         return "?v=" . $this->getAppendVersion();
     }
 
-    public function getVersionUrl($url)
-    {
-        if ($this->isEnabled()) {
-            return $url . $this->getAppendVersionString();
-        } else {
-            return $url;
-        }
-    }
-
     public function appendVersionToTags($html)
     {
-        // DOMDocument absolutely hates us all (ref: http://stackoverflow.com/a/29499398/2929617)
-        $doc = new DOMDocument();
-        $doc->loadHTML("<div>$html</div>", LIBXML_HTML_NODEFDTD);
-        $container = $doc->getElementsByTagName('div')->item(0);
-        $container = $container->parentNode->removeChild($container);
-        while ($doc->firstChild) {
-            $doc->removeChild($doc->firstChild);
-        }
-        while ($container->firstChild) {
-            $doc->appendChild($container->firstChild);
-        }
 
-        // Process all the script tags
-        foreach ($doc->getElementsByTagName('script') as $script) {
-            if ($script->hasAttribute('src')) {
-                $script->setAttribute('src', $script->getAttribute('src') . $this->getAppendVersionString());
-            }
-        }
+        // CSS
+        $html = preg_replace_callback(
+            "/href=['\"][^'\"]+?\.css[^'\"]*/",
+            function ($matches) {
+                return $matches[0] . $this->getAppendVersionString();
+            },
+            $html
+        );
 
-        // Process all the link tags (stylesheets)
-        foreach ($doc->getElementsByTagName('link') as $link) {
-            if ($link->hasAttribute('href') && $link->hasAttribute('rel')) {
-                if ($link->getAttribute('rel') == 'stylesheet') {
-                    $link->setAttribute('href', $link->getAttribute('href') . $this->getAppendVersionString());
-                }
-            }
-        }
+        // JS
+        $html = preg_replace_callback(
+            "/src=['\"][^'\"]+?\.js[^'\"]*/",
+            function ($matches) {
+                return $matches[0] . $this->getAppendVersionString();
+            },
+            $html
+        );
 
-        return $doc->saveHTML();
+        return $html;
     }
 
     public function updateVersion()

--- a/src/app/code/community/Leytech/CssJsVersion/etc/config.xml
+++ b/src/app/code/community/Leytech/CssJsVersion/etc/config.xml
@@ -10,7 +10,7 @@
 <config>
     <modules>
         <Leytech_CssJsVersion>
-            <version>1.0.0</version>
+            <version>1.0.1</version>
         </Leytech_CssJsVersion>
     </modules>
     <global>
@@ -25,15 +25,6 @@
             </leytech_cssjsversion>
         </helpers>
         <events>
-            <core_block_abstract_to_html_after>
-                <observers>
-                    <leytech_cssjsversion_block>
-                        <type>singleton</type>
-                        <class>Leytech_CssJsVersion_Model_Observer</class>
-                        <method>processBlockHtml</method>
-                    </leytech_cssjsversion_block>
-                </observers>
-            </core_block_abstract_to_html_after>
             <adminhtml_cache_refresh_type>
                 <observers>
                     <leytech_cssjsversion_cache_type>
@@ -63,6 +54,19 @@
             </adminhtml_cache_flush_all>
         </events>
     </global>
+    <frontend>
+        <events>
+            <core_block_abstract_to_html_after>
+                <observers>
+                    <leytech_cssjsversion_block>
+                        <type>singleton</type>
+                        <class>Leytech_CssJsVersion_Model_Observer</class>
+                        <method>processBlockHtml</method>
+                    </leytech_cssjsversion_block>
+                </observers>
+            </core_block_abstract_to_html_after>
+        </events>
+    </frontend>
     <default>
         <leytech_cssjsversion>
             <settings>


### PR DESCRIPTION
Use preg_replace instead of DOMDocument which was unreliable and broke several sites.
Observe frontend only so adminhtml assets are not versioned.